### PR TITLE
Add listLeaderboardRecords method

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   fixnum:
     dependency: transitive
     description:
@@ -171,7 +171,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -192,7 +192,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pedantic:
     dependency: transitive
     description:
@@ -218,7 +218,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -253,7 +253,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -267,7 +267,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   web_socket_channel:
     dependency: transitive
     description:
@@ -276,4 +276,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/lib/src/nakama_client/nakama_api_client.dart
+++ b/lib/src/nakama_client/nakama_api_client.dart
@@ -392,22 +392,26 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
-  Future<void> listLeaderboardRecords({
+  Future<LeaderboardRecordList> listLeaderboardRecords({
     required model.Session session,
     required String leaderboardId,
     List<String>? ownerIds,
-    int? limit,
+    int limit = 20,
     String? cursor,
     String? expiry,
-  }) {
+  }) async {
+    assert(limit > 0 && limit <= 100);
+
     _session = session;
 
-    return _api.nakamaListLeaderboardRecords(
+    final res = await _api.nakamaListLeaderboardRecords(
       leaderboardId: leaderboardId,
       ownerIds: ownerIds,
       limit: limit,
       cursor: cursor,
       expiry: expiry,
     );
+
+    return LeaderboardRecordList()..mergeFromProto3Json(res.body!.toJson());
   }
 }

--- a/lib/src/nakama_client/nakama_api_client.dart
+++ b/lib/src/nakama_client/nakama_api_client.dart
@@ -390,4 +390,24 @@ class NakamaRestApiClient extends NakamaBaseClient {
 
     return ChannelMessageList()..mergeFromProto3Json(res.body!.toJson());
   }
+
+  @override
+  Future<void> listLeaderboardRecords({
+    required model.Session session,
+    required String leaderboardId,
+    List<String>? ownerIds,
+    int? limit,
+    String? cursor,
+    String? expiry,
+  }) {
+    _session = session;
+
+    return _api.nakamaListLeaderboardRecords(
+      leaderboardId: leaderboardId,
+      ownerIds: ownerIds,
+      limit: limit,
+      cursor: cursor,
+      expiry: expiry,
+    );
+  }
 }

--- a/lib/src/nakama_client/nakama_api_client.dart
+++ b/lib/src/nakama_client/nakama_api_client.dart
@@ -394,7 +394,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     List<String>? ownerIds,
     int limit = 20,
     String? cursor,
-    String? expiry,
+    DateTime? expiry,
   }) async {
     assert(limit > 0 && limit <= 100);
 
@@ -405,7 +405,9 @@ class NakamaRestApiClient extends NakamaBaseClient {
       ownerIds: ownerIds,
       limit: limit,
       cursor: cursor,
-      expiry: expiry,
+      expiry: expiry == null
+          ? null
+          : (expiry.millisecondsSinceEpoch ~/ 1000).toString(),
     );
 
     return LeaderboardRecordList()..mergeFromProto3Json(res.body!.toJson());

--- a/lib/src/nakama_client/nakama_api_client.dart
+++ b/lib/src/nakama_client/nakama_api_client.dart
@@ -394,7 +394,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
   @override
   Future<LeaderboardRecordList> listLeaderboardRecords({
     required model.Session session,
-    required String leaderboardId,
+    required String leaderboardName,
     List<String>? ownerIds,
     int limit = 20,
     String? cursor,
@@ -405,7 +405,7 @@ class NakamaRestApiClient extends NakamaBaseClient {
     _session = session;
 
     final res = await _api.nakamaListLeaderboardRecords(
-      leaderboardId: leaderboardId,
+      leaderboardId: leaderboardName,
       ownerIds: ownerIds,
       limit: limit,
       cursor: cursor,

--- a/lib/src/nakama_client/nakama_client.dart
+++ b/lib/src/nakama_client/nakama_client.dart
@@ -1,6 +1,5 @@
 import 'package:nakama/api.dart';
 import 'package:nakama/nakama.dart';
-import 'package:nakama/src/rest/apigrpc.swagger.dart';
 import 'package:nakama/src/session.dart' as model;
 
 const _kDefaultAppKey = 'default';
@@ -104,11 +103,11 @@ abstract class NakamaBaseClient {
     String? cursor,
   });
 
-  Future<void> listLeaderboardRecords({
+  Future<LeaderboardRecordList> listLeaderboardRecords({
     required model.Session session,
     required String leaderboardId,
     List<String>? ownerIds,
-    int? limit,
+    int limit = 20,
     String? cursor,
     String? expiry,
   });

--- a/lib/src/nakama_client/nakama_client.dart
+++ b/lib/src/nakama_client/nakama_client.dart
@@ -105,7 +105,7 @@ abstract class NakamaBaseClient {
 
   Future<LeaderboardRecordList> listLeaderboardRecords({
     required model.Session session,
-    required String leaderboardId,
+    required String leaderboardName,
     List<String>? ownerIds,
     int limit = 20,
     String? cursor,

--- a/lib/src/nakama_client/nakama_client.dart
+++ b/lib/src/nakama_client/nakama_client.dart
@@ -103,4 +103,13 @@ abstract class NakamaBaseClient {
     bool? forward,
     String? cursor,
   });
+
+  Future<void> listLeaderboardRecords({
+    required model.Session session,
+    required String leaderboardId,
+    List<String>? ownerIds,
+    int? limit,
+    String? cursor,
+    String? expiry,
+  });
 }

--- a/lib/src/nakama_client/nakama_client.dart
+++ b/lib/src/nakama_client/nakama_client.dart
@@ -109,6 +109,6 @@ abstract class NakamaBaseClient {
     List<String>? ownerIds,
     int limit = 20,
     String? cursor,
-    String? expiry,
+    DateTime? expiry,
   });
 }

--- a/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/lib/src/nakama_client/nakama_grpc_client.dart
@@ -370,22 +370,23 @@ class NakamaGrpcClient extends NakamaBaseClient {
   @override
   Future<LeaderboardRecordList> listLeaderboardRecords({
     required model.Session session,
-    required String leaderboardId,
+    required String leaderboardName,
     List<String>? ownerIds,
     int limit = 20,
     String? cursor,
-    String? expiry,
+    DateTime? expiry,
   }) async {
     assert(limit > 0 && limit <= 100);
 
     return await _client.listLeaderboardRecords(
       ListLeaderboardRecordsRequest(
-        leaderboardId: leaderboardId,
+        leaderboardId: leaderboardName,
         ownerIds: ownerIds,
         limit: Int32Value(value: limit),
         cursor: cursor,
-        expiry:
-            expiry == null ? null : Int64Value(value: Int64(int.parse(expiry))),
+        expiry: expiry == null
+            ? null
+            : Int64Value(value: Int64(expiry.millisecondsSinceEpoch ~/ 1000)),
       ),
       options: _getSessionCallOptions(session),
     );

--- a/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/lib/src/nakama_client/nakama_grpc_client.dart
@@ -368,4 +368,22 @@ class NakamaGrpcClient extends NakamaBaseClient {
       options: _getSessionCallOptions(session),
     );
   }
+
+  @override
+  Future<void> listLeaderboardRecords({
+    required model.Session session,
+    required String leaderboardId,
+    List<String>? ownerIds,
+    int? limit,
+    String? cursor,
+    String? expiry,
+  }) {
+    return _client.listLeaderboardRecords(ListLeaderboardRecordsRequest(
+      leaderboardId: leaderboardId,
+      ownerIds: ownerIds,
+      limit: limit, // Int32Value?
+      cursor: cursor,
+      expiry: expiry, // Int64Value?
+    ));
+  }
 }

--- a/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/lib/src/nakama_client/nakama_grpc_client.dart
@@ -6,7 +6,6 @@ import 'package:logging/logging.dart';
 import 'package:nakama/api.dart';
 import 'package:nakama/nakama.dart';
 import 'package:nakama/src/api/proto/apigrpc/apigrpc.pbgrpc.dart';
-import 'package:nakama/src/rest/apigrpc.swagger.dart';
 import 'package:nakama/src/session.dart' as model;
 
 const _kDefaultAppKey = 'default';
@@ -370,20 +369,26 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
-  Future<void> listLeaderboardRecords({
+  Future<LeaderboardRecordList> listLeaderboardRecords({
     required model.Session session,
     required String leaderboardId,
     List<String>? ownerIds,
-    int? limit,
+    int limit = 20,
     String? cursor,
     String? expiry,
-  }) {
-    return _client.listLeaderboardRecords(ListLeaderboardRecordsRequest(
-      leaderboardId: leaderboardId,
-      ownerIds: ownerIds,
-      limit: limit, // Int32Value?
-      cursor: cursor,
-      expiry: expiry, // Int64Value?
-    ));
+  }) async {
+    assert(limit > 0 && limit <= 100);
+
+    return await _client.listLeaderboardRecords(
+      ListLeaderboardRecordsRequest(
+        leaderboardId: leaderboardId,
+        ownerIds: ownerIds,
+        limit: Int32Value(value: limit),
+        cursor: cursor,
+        expiry:
+            expiry == null ? null : Int64Value(value: Int64(int.parse(expiry))),
+      ),
+      options: _getSessionCallOptions(session),
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -154,7 +154,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -348,7 +348,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: "direct main"
     description:
@@ -577,7 +577,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:

--- a/test/grpc/leaderboard_test.dart
+++ b/test/grpc/leaderboard_test.dart
@@ -1,0 +1,32 @@
+import 'package:faker/faker.dart';
+import 'package:nakama/api.dart' as api;
+import 'package:nakama/nakama.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+import '../config.dart';
+
+void main() {
+  group('[gRPC] Test Leaderboard', () {
+    late final NakamaBaseClient client;
+    late final Session session;
+
+    setUpAll(() async {
+      client = getNakamaClient(
+        host: kTestHost,
+        ssl: false,
+        serverKey: kTestServerKey,
+      );
+
+      session = await client.authenticateDevice(deviceId: faker.guid.guid());
+    });
+
+    test('list leaderboard records', () async {
+      final result = await client.listLeaderboardRecords(
+          session: session, leaderboardId: 'test');
+
+      expect(result, isA<api.LeaderboardRecordList>());
+      expect(result.records, hasLength(0));
+    });
+  });
+}

--- a/test/grpc/leaderboard_test.dart
+++ b/test/grpc/leaderboard_test.dart
@@ -28,7 +28,6 @@ void main() {
       );
 
       expect(result, isA<api.LeaderboardRecordList>());
-      expect(result.records, hasLength(0));
     });
   });
 }

--- a/test/grpc/leaderboard_test.dart
+++ b/test/grpc/leaderboard_test.dart
@@ -23,7 +23,9 @@ void main() {
 
     test('list leaderboard records', () async {
       final result = await client.listLeaderboardRecords(
-          session: session, leaderboardId: 'test');
+        session: session,
+        leaderboardName: 'test',
+      );
 
       expect(result, isA<api.LeaderboardRecordList>());
       expect(result.records, hasLength(0));

--- a/test/rest/leaderboard_test.dart
+++ b/test/rest/leaderboard_test.dart
@@ -1,0 +1,31 @@
+import 'package:faker/faker.dart';
+import 'package:nakama/api.dart' as api;
+import 'package:nakama/nakama.dart';
+import 'package:test/test.dart';
+
+import '../config.dart';
+
+void main() {
+  group('[REST] Test Leaderboard', () {
+    late final NakamaBaseClient client;
+    late final Session session;
+
+    setUpAll(() async {
+      client = NakamaRestApiClient.init(
+        host: kTestHost,
+        ssl: false,
+        serverKey: kTestServerKey,
+      );
+
+      session = await client.authenticateDevice(deviceId: faker.guid.guid());
+    });
+
+    test('list leaderboard records', () async {
+      final result = await client.listLeaderboardRecords(
+          session: session, leaderboardId: 'test');
+
+      expect(result, isA<api.LeaderboardRecordList>());
+      expect(result.records, hasLength(0));
+    });
+  });
+}

--- a/test/rest/leaderboard_test.dart
+++ b/test/rest/leaderboard_test.dart
@@ -27,7 +27,6 @@ void main() {
       );
 
       expect(result, isA<api.LeaderboardRecordList>());
-      expect(result.records, hasLength(0));
     });
   });
 }

--- a/test/rest/leaderboard_test.dart
+++ b/test/rest/leaderboard_test.dart
@@ -22,7 +22,9 @@ void main() {
 
     test('list leaderboard records', () async {
       final result = await client.listLeaderboardRecords(
-          session: session, leaderboardId: 'test');
+        session: session,
+        leaderboardName: 'test',
+      );
 
       expect(result, isA<api.LeaderboardRecordList>());
       expect(result.records, hasLength(0));

--- a/tool/nakama_server/modules/main.lua
+++ b/tool/nakama_server/modules/main.lua
@@ -1,0 +1,5 @@
+local nk = require("nakama")
+
+nk.run_once(function(context)
+    nk.leaderboard_create("test", false, "desc", "incr", "0 0 * * *", {})
+end)


### PR DESCRIPTION
This adds listLeaderboardRecords method to the client.

This is my first PR to a Flutter/Dart project, so there might be some obvious points I'm missing.

Part of https://github.com/obrunsmann/flutter_nakama/issues/7