### PR TITLE
Add readStorageObject method

### DIFF
--- a/lib/src/nakama_client/nakama_api_client.dart
+++ b/lib/src/nakama_client/nakama_api_client.dart
@@ -367,6 +367,31 @@ class NakamaRestApiClient extends NakamaBaseClient {
   }
 
   @override
+  Future<StorageObject> readStorageObject({
+    required model.Session session,
+    String? collection,
+    String? key,
+    String? userId,
+  }) async {
+    _session = session;
+
+    final res = await _api.nakamaReadStorageObjects(
+      body: ApiReadStorageObjectsRequest(
+        objectIds: [
+          ApiReadStorageObjectId(
+            collection: collection,
+            key: key,
+            userId: userId,
+          ),
+        ],
+      ),
+    );
+
+    final result = StorageObjects()..mergeFromProto3Json(res.body!.toJson());
+    return result.objects.first;
+  }
+
+  @override
   Future<ChannelMessageList?> listChannelMessages({
     required model.Session session,
     required String channelId,

--- a/lib/src/nakama_client/nakama_api_client.dart
+++ b/lib/src/nakama_client/nakama_api_client.dart
@@ -358,12 +358,8 @@ class NakamaRestApiClient extends NakamaBaseClient {
             key: key,
             value: value,
             version: version,
-            permissionWrite: writePermission != null
-                ? StorageWritePermission.values.indexOf(writePermission)
-                : null,
-            permissionRead: readPermission != null
-                ? StorageReadPermission.values.indexOf(readPermission)
-                : null,
+            permissionWrite: writePermission?.index,
+            permissionRead: readPermission?.index,
           ),
         ],
       ),

--- a/lib/src/nakama_client/nakama_client.dart
+++ b/lib/src/nakama_client/nakama_client.dart
@@ -96,6 +96,13 @@ abstract class NakamaBaseClient {
     StorageReadPermission? readPermission,
   });
 
+  Future<StorageObject> readStorageObject({
+    required model.Session session,
+    String? collection,
+    String? key,
+    String? userId,
+  });
+
   Future<ChannelMessageList?> listChannelMessages({
     required model.Session session,
     required String channelId,

--- a/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/lib/src/nakama_client/nakama_grpc_client.dart
@@ -348,6 +348,29 @@ class NakamaGrpcClient extends NakamaBaseClient {
   }
 
   @override
+  Future<StorageObject> readStorageObject({
+    required model.Session session,
+    String? collection,
+    String? key,
+    String? userId,
+  }) async {
+    final res = await _client.readStorageObjects(
+      ReadStorageObjectsRequest(
+        objectIds: [
+          ReadStorageObjectId(
+            collection: collection,
+            key: key,
+            userId: userId,
+          ),
+        ],
+      ),
+      options: _getSessionCallOptions(session),
+    );
+
+    return res.objects.first;
+  }
+
+  @override
   Future<ChannelMessageList?> listChannelMessages({
     required model.Session session,
     required String channelId,

--- a/lib/src/nakama_client/nakama_grpc_client.dart
+++ b/lib/src/nakama_client/nakama_grpc_client.dart
@@ -326,26 +326,25 @@ class NakamaGrpcClient extends NakamaBaseClient {
     StorageWritePermission? writePermission,
     StorageReadPermission? readPermission,
   }) {
-    return _client.writeStorageObjects(WriteStorageObjectsRequest(
-      objects: [
-        WriteStorageObject(
-          collection: collection,
-          key: key,
-          value: value,
-          version: version,
-          permissionWrite: writePermission != null
-              ? Int32Value(
-                  value: StorageWritePermission.values.indexOf(writePermission),
-                )
-              : null,
-          permissionRead: readPermission != null
-              ? Int32Value(
-                  value: StorageReadPermission.values.indexOf(readPermission),
-                )
-              : null,
-        ),
-      ],
-    ));
+    return _client.writeStorageObjects(
+      WriteStorageObjectsRequest(
+        objects: [
+          WriteStorageObject(
+            collection: collection,
+            key: key,
+            value: value,
+            version: version,
+            permissionWrite: writePermission != null
+                ? Int32Value(value: writePermission.index)
+                : null,
+            permissionRead: readPermission != null
+                ? Int32Value(value: readPermission.index)
+                : null,
+          ),
+        ],
+      ),
+      options: _getSessionCallOptions(session),
+    );
   }
 
   @override

--- a/test/grpc/storage_test.dart
+++ b/test/grpc/storage_test.dart
@@ -25,7 +25,7 @@ void main() {
         session: session,
         collection: 'stats',
         key: 'skills',
-        value: '{"skill":25}',
+        value: '{"skill": 25}',
       );
     });
 
@@ -34,10 +34,22 @@ void main() {
         session: session,
         collection: 'stats',
         key: 'scores',
-        value: '{"skill":25}',
+        value: '{"skill": 25}',
         writePermission: StorageWritePermission.ownerWrite,
         readPermission: StorageReadPermission.publicRead,
       );
+    });
+
+    test('read storage object', () async {
+      final res = await client.readStorageObject(
+        session: session,
+        collection: 'stats',
+        key: 'skills',
+        userId: session.userId,
+      );
+
+      expect(res, isA<api.StorageObject>());
+      expect(res.value, equals('{"skill": 25}'));
     });
   });
 }

--- a/test/grpc/storage_test.dart
+++ b/test/grpc/storage_test.dart
@@ -1,0 +1,43 @@
+import 'package:faker/faker.dart';
+import 'package:nakama/api.dart' as api;
+import 'package:nakama/nakama.dart';
+import 'package:test/test.dart';
+
+import '../config.dart';
+
+void main() {
+  group('[gRPC] Test Storage Engine', () {
+    late final NakamaBaseClient client;
+    late final Session session;
+
+    setUpAll(() async {
+      client = getNakamaClient(
+        host: kTestHost,
+        ssl: false,
+        serverKey: kTestServerKey,
+      );
+
+      session = await client.authenticateDevice(deviceId: faker.guid.guid());
+    });
+
+    test('write storage object', () async {
+      await client.writeStorageObject(
+        session: session,
+        collection: 'stats',
+        key: 'skills',
+        value: '{"skill":25}',
+      );
+    });
+
+    test('write storage object with permissions', () async {
+      await client.writeStorageObject(
+        session: session,
+        collection: 'stats',
+        key: 'scores',
+        value: '{"skill":25}',
+        writePermission: StorageWritePermission.ownerWrite,
+        readPermission: StorageReadPermission.publicRead,
+      );
+    });
+  });
+}

--- a/test/rest/storage_test.dart
+++ b/test/rest/storage_test.dart
@@ -1,0 +1,43 @@
+import 'package:faker/faker.dart';
+import 'package:nakama/api.dart' as api;
+import 'package:nakama/nakama.dart';
+import 'package:test/test.dart';
+
+import '../config.dart';
+
+void main() {
+  group('[REST] Test Storage Engine', () {
+    late final NakamaBaseClient client;
+    late final Session session;
+
+    setUpAll(() async {
+      client = NakamaRestApiClient.init(
+        host: kTestHost,
+        ssl: false,
+        serverKey: kTestServerKey,
+      );
+
+      session = await client.authenticateDevice(deviceId: faker.guid.guid());
+    });
+
+    test('write storage object', () async {
+      await client.writeStorageObject(
+        session: session,
+        collection: 'stats',
+        key: 'skills',
+        value: '{"skill":25}',
+      );
+    });
+
+    test('write storage object with permissions', () async {
+      await client.writeStorageObject(
+        session: session,
+        collection: 'stats',
+        key: 'scores',
+        value: '{"skill":25}',
+        writePermission: StorageWritePermission.ownerWrite,
+        readPermission: StorageReadPermission.publicRead,
+      );
+    });
+  });
+}

--- a/test/rest/storage_test.dart
+++ b/test/rest/storage_test.dart
@@ -39,5 +39,17 @@ void main() {
         readPermission: StorageReadPermission.publicRead,
       );
     });
+
+    test('read storage object', () async {
+      final res = await client.readStorageObject(
+        session: session,
+        collection: 'stats',
+        key: 'skills',
+        userId: session.userId,
+      );
+
+      expect(res, isA<api.StorageObject>());
+      expect(res.value, equals('{"skill": 25}'));
+    });
   });
 }


### PR DESCRIPTION
Should be reviewed after #35.

Adds readStorageObject method with tests. I followed the pattern already done for writeStorageObject which is a bit different from official client, as it will allow creating and reading one object with each call.
Hence this method is `readStorageObject` not `readStorageObjects`.